### PR TITLE
Fix exception name (#5)

### DIFF
--- a/inventory.py
+++ b/inventory.py
@@ -48,8 +48,8 @@ def make_request_using_api_utils(url: str, params: Dict[str, Union[str, int]] = 
             try:
                 response_data = json.loads(response.text)
                 return response_data
-            except JsonDecoderError:
-                logger.warning('JsonDecoderError encountered')
+            except JSONDecodeError:
+                logger.warning('JSONDecodeError encountered')
                 logger.info('Beginning next attempt')
 
     logger.error('The maximum number of reqeust attempts was reached')


### PR DESCRIPTION
In my last PR, #6, I misspelled the exception type as `JsonDecoderError`, even though I imported the right exception type, `JSONDecodeError`. This PR corrects my mistake and aims to finish resolving issue #5.

See docs:
https://docs.python.org/3/library/json.html#json.JSONDecodeError