### PR TITLE
Add sis_id to user table (#22)

### DIFF
--- a/db/migrations/0004.add_sis_id.py
+++ b/db/migrations/0004.add_sis_id.py
@@ -1,0 +1,8 @@
+#
+# file: migrations/0004.add_sis_id.py
+#
+from yoyo import step
+
+__depends__ = {'0003.created_date_datatype_change'}
+
+step("ALTER TABLE user ADD column sis_id INTEGER NULL AFTER name;")

--- a/db/migrations/0004.add_um_id.py
+++ b/db/migrations/0004.add_um_id.py
@@ -1,8 +1,0 @@
-#
-# file: migrations/0004.add_um_id.py
-#
-from yoyo import step
-
-__depends__ = {'0003.created_date_datatype_change'}
-
-step("ALTER TABLE user ADD column um_id INTEGER NULL AFTER name;")

--- a/db/migrations/0004.add_um_id.py
+++ b/db/migrations/0004.add_um_id.py
@@ -1,0 +1,8 @@
+#
+# file: migrations/0004.add_um_id.py
+#
+from yoyo import step
+
+__depends__ = {'0003.created_date_datatype_change'}
+
+step("ALTER TABLE user ADD column um_id INTEGER NULL AFTER name;")

--- a/inventory.py
+++ b/inventory.py
@@ -144,12 +144,23 @@ def pull_enrollment_data_from_udw(course_ids) -> pd.DataFrame:
     return enrollment_df
 
 
+def process_um_id(id: Union[str, None]) -> Union[int, None]:
+    if id is not None:
+        try:
+            um_id = int(id)
+            return um_id
+        except ValueError:
+            logger.debug(f'Invalid um_id found: {id}')
+    return None
+
+
 def pull_user_data_from_udw(user_ids: Sequence[int]) -> pd.DataFrame:
     users_string = ','.join([str(user_id) for user_id in user_ids])
     user_query = f'''
         SELECT u.id AS warehouse_id,
                u.canvas_id AS canvas_id,
                u.name AS name,
+               p.sis_user_id AS um_id,
                p.unique_name AS uniqname,
                u.workflow_state AS workflow_state
         FROM user_dim u
@@ -160,6 +171,7 @@ def pull_user_data_from_udw(user_ids: Sequence[int]) -> pd.DataFrame:
     logger.info('Making user_dim query')
     user_df = pd.read_sql(user_query, UDW_CONN)
     # Found that the IDs are not necessarily unique, so dropping duplicates
+    user_df['um_id'] = user_df['um_id'].map(process_um_id)
     user_df = user_df.drop_duplicates(subset=['warehouse_id', 'canvas_id'])
     logger.debug(user_df.head())
     return user_df

--- a/inventory.py
+++ b/inventory.py
@@ -144,13 +144,13 @@ def pull_enrollment_data_from_udw(course_ids) -> pd.DataFrame:
     return enrollment_df
 
 
-def process_um_id(id: str) -> Union[int, None]:
+def process_sis_id(id: str) -> Union[int, None]:
     try:
-        um_id = int(id)
+        sis_id = int(id)
     except ValueError:
-        logger.debug(f'Invalid um_id found: {id}')
-        um_id = None
-    return um_id
+        logger.debug(f'Invalid sis_id found: {id}')
+        sis_id = None
+    return sis_id
 
 
 def pull_user_data_from_udw(user_ids: Sequence[int]) -> pd.DataFrame:
@@ -159,7 +159,7 @@ def pull_user_data_from_udw(user_ids: Sequence[int]) -> pd.DataFrame:
         SELECT u.id AS warehouse_id,
                u.canvas_id AS canvas_id,
                u.name AS name,
-               p.sis_user_id AS um_id,
+               p.sis_user_id AS sis_id,
                p.unique_name AS uniqname,
                u.workflow_state AS workflow_state
         FROM user_dim u
@@ -170,7 +170,7 @@ def pull_user_data_from_udw(user_ids: Sequence[int]) -> pd.DataFrame:
     logger.info('Making user_dim query')
     user_df = pd.read_sql(user_query, UDW_CONN)
     # Found that the IDs are not necessarily unique, so dropping duplicates
-    user_df['um_id'] = user_df['um_id'].map(process_um_id, na_action='ignore')
+    user_df['sis_id'] = user_df['sis_id'].map(process_sis_id, na_action='ignore')
     user_df = user_df.drop_duplicates(subset=['warehouse_id', 'canvas_id'])
     logger.debug(user_df.head())
     return user_df

--- a/inventory.py
+++ b/inventory.py
@@ -144,14 +144,13 @@ def pull_enrollment_data_from_udw(course_ids) -> pd.DataFrame:
     return enrollment_df
 
 
-def process_um_id(id: Union[str, None]) -> Union[int, None]:
-    if id is not None:
-        try:
-            um_id = int(id)
-            return um_id
-        except ValueError:
-            logger.debug(f'Invalid um_id found: {id}')
-    return None
+def process_um_id(id: str) -> Union[int, None]:
+    try:
+        um_id = int(id)
+    except ValueError:
+        logger.debug(f'Invalid um_id found: {id}')
+        um_id = None
+    return um_id
 
 
 def pull_user_data_from_udw(user_ids: Sequence[int]) -> pd.DataFrame:
@@ -171,7 +170,7 @@ def pull_user_data_from_udw(user_ids: Sequence[int]) -> pd.DataFrame:
     logger.info('Making user_dim query')
     user_df = pd.read_sql(user_query, UDW_CONN)
     # Found that the IDs are not necessarily unique, so dropping duplicates
-    user_df['um_id'] = user_df['um_id'].map(process_um_id)
+    user_df['um_id'] = user_df['um_id'].map(process_um_id, na_action='ignore')
     user_df = user_df.drop_duplicates(subset=['warehouse_id', 'canvas_id'])
     logger.debug(user_df.head())
     return user_df


### PR DESCRIPTION
This PR makes adds a migration and makes modifications to the existing UDW user query in order to add `user.sis_id` (a user's UM ID) to the database. It pulls the `sis_id` from the `sis_user_id` column of the `pseudonym_dim` table. Some processing is done to ensure that the value is an integer. The cases where they are not seem to be for friend accounts, where the value is an email. This PR aims to resolve issue #22.