### PR TITLE
Use quote_plus on db password string (#46)

### DIFF
--- a/db/db_creator.py
+++ b/db/db_creator.py
@@ -1,6 +1,7 @@
 # standard libraries
 import logging, os
 from typing import Dict, Sequence
+from urllib.parse import quote_plus
 
 # third-party libraries
 from sqlalchemy.engine import create_engine
@@ -20,7 +21,7 @@ class DBCreator:
         self.conn_str = (
             'mysql+mysqldb' +
             f"://{db_params['user']}" +
-            f":{db_params['password']}" +
+            f":{quote_plus(db_params['password'])}" +
             f"@{db_params['host']}" +
             f":{db_params['port']}" +
             f"/{db_params['dbname']}?charset=utf8"


### PR DESCRIPTION
This PR changes `db_creator` to pass the MySQL database password string through `quote_plus` (from `urllib.parse`) before using it in the connection string to ensure that special characters do not disrupt authentication. The PR aims to resolve issue #46.

I tested this by adding a problematic character to the password in `docker-compose.yml`, deleting the `.data` directory, and changing the password in my mapped `env.json`. It failed without the change and succeeded with it.