### PR TITLE
Add sis_id columns to course and course_section tables (#42)

### DIFF
--- a/db/migrations/0011.add_course_sis_ids.py
+++ b/db/migrations/0011.add_course_sis_ids.py
@@ -1,0 +1,18 @@
+#
+# file: migrations/0011.add_course_sis_ids.py
+#
+from yoyo import step
+
+__depends__ = {'0010.add_fkc_course_usage_table'}
+
+
+steps = [
+    step('''
+        ALTER TABLE course
+        ADD COLUMN sis_id BIGINT NULL AFTER canvas_id;
+    '''),
+    step('''
+        ALTER TABLE course_section
+        ADD COLUMN sis_id BIGINT NULL AFTER canvas_id;
+    ''')
+]


### PR DESCRIPTION
This PR adds a migration and modifies `course_inventory/inventory.py` in order to add and populate `sis_id` columns in the `course` and `course_section` tables of the database. In addition, I modified an existing UDW query to use the `params` parameter of `pd.read_sql`, hopefully resolving a SQL injection warning raised by Codacy. Also, I modified the existing `process_sis_id` mapping function so it could be used to also drop non-integer SIS ID values for sections. This PR aims to resolve issue #42.

Resolves #42.