### PR TITLE
#88 enabling SSL to support connections within MiServer

### DIFF
--- a/db/db_creator.py
+++ b/db/db_creator.py
@@ -29,7 +29,7 @@ class DBCreator:
             f":{quote_plus(db_params['password'])}" +
             f"@{db_params['host']}" +
             f":{db_params['port']}" +
-            f"/{db_params['dbname']}?charset=utf8"
+            f"/{db_params['dbname']}?charset=utf8&ssl=true"
         )
         self.engine = create_engine(self.conn_str)
         self.append_table_names = append_table_names


### PR DESCRIPTION
I was able to test this on all the following scenarios
1. Miserver instance: Tesla
2. Localhost mysql DB instance
3. From Docker compose build

Resolves #88.