### PR TITLE
Pull enumerations from run_jobs.py into separate vocab.py module (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,11 +297,12 @@ All the changes described below (minus the configuration changes) should be incl
 
     ```json
     {
-        "data_source_name": "SOME_DATA_SOURCE",
+        "data_source_name": valid_data_source_name_member,
         "data_updated_at": some_timestamp
     }
     ```
 
+    For `valid_data_source_name_member`, use a member of the `ValidDataSourceName` enumeration defined in `vocab.py`.
     If the data source provides a timestamp for the data, use that; otherwise, use the current time. 
     For consistency, `some_timestamp` should be generated using 
     [the `pandas` method `pd.to_datetime`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.to_datetime.html).

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -13,6 +13,7 @@ from umich_api.api_utils import ApiUtil
 # local libraries
 from db.db_creator import DBCreator
 from environ import ENV
+from vocab import ValidDataSourceName
 from .async_enroll_gatherer import AsyncEnrollGatherer
 from .canvas_course_usage import CanvasCourseUsage
 from .gql_queries import queries as QUERIES
@@ -227,7 +228,7 @@ def run_course_inventory() -> Sequence[Dict[str, Union[str, pd.Timestamp]]]:
 
     # Record data source info for Canvas API
     canvas_data_source = {
-        'data_source_name': 'CANVAS_API',
+        'data_source_name': ValidDataSourceName.CANVAS_API.name,
         'data_updated_at': pd.to_datetime(time.time(), unit='s', utc=True)
     }
 
@@ -250,7 +251,7 @@ def run_course_inventory() -> Sequence[Dict[str, Union[str, pd.Timestamp]]]:
     logger.info(f'Found canvasdatadate in UDW of {udw_update_datetime}')
 
     udw_data_source = {
-        'data_source_name': 'UNIZIN_DATA_WAREHOUSE',
+        'data_source_name': ValidDataSourceName.UNIZIN_DATA_WAREHOUSE.name,
         'data_updated_at': udw_update_datetime
     }
 

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -181,7 +181,7 @@ def pull_sis_section_data_from_udw(section_ids: Sequence[int], conn: connection)
 
 # Entry point for run_jobs.py
 
-def run_course_inventory() -> Sequence[Dict[str, Union[str, pd.Timestamp]]]:
+def run_course_inventory() -> Sequence[Dict[str, Union[ValidDataSourceName, pd.Timestamp]]]:
     logger.info("* run_course_inventory")
     logger.info('Making requests against the Canvas API')
 
@@ -228,7 +228,7 @@ def run_course_inventory() -> Sequence[Dict[str, Union[str, pd.Timestamp]]]:
 
     # Record data source info for Canvas API
     canvas_data_source = {
-        'data_source_name': ValidDataSourceName.CANVAS_API.name,
+        'data_source_name': ValidDataSourceName.CANVAS_API,
         'data_updated_at': pd.to_datetime(time.time(), unit='s', utc=True)
     }
 
@@ -251,7 +251,7 @@ def run_course_inventory() -> Sequence[Dict[str, Union[str, pd.Timestamp]]]:
     logger.info(f'Found canvasdatadate in UDW of {udw_update_datetime}')
 
     udw_data_source = {
-        'data_source_name': ValidDataSourceName.UNIZIN_DATA_WAREHOUSE.name,
+        'data_source_name': ValidDataSourceName.UNIZIN_DATA_WAREHOUSE,
         'data_updated_at': udw_update_datetime
     }
 

--- a/run_jobs.py
+++ b/run_jobs.py
@@ -1,15 +1,15 @@
 # standard libraries
 import logging, os, time
-from enum import auto, Enum
 from importlib import import_module
 from typing import Dict, Sequence, Union
+
+# third-party libraries
+import pandas as pd
 
 # local libraries
 from db.db_creator import DBCreator
 from environ import ENV
-
-# third-party libraries
-import pandas as pd
+from vocab import ValidJobName, ValidDataSourceName
 
 
 # Initialize settings and global variables
@@ -19,26 +19,6 @@ logging.basicConfig(
     level=ENV.get('LOG_LEVEL', 'DEBUG'),
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
-
-
-# Enum(s)
-
-# Each job name should be defined in ValidJobName.
-# NAME_OF_JOB = 'path.to.method'
-
-class ValidJobName(Enum):
-    COURSE_INVENTORY = 'course_inventory.inventory.run_course_inventory'
-    # ONLINE_MEETINGS = 'online_meetings.report...'
-    # ZOOM = 'online_meetings.canvas_zoom_meetings...'
-    # MIVIDEO = 'mivideo...'
-
-
-# Each data source name should be defined in ValidDataSourceName.
-# NAME_OF_DATA_SOURCE = auto()
-
-class ValidDataSourceName(Enum):
-    CANVAS_API = auto()
-    UNIZIN_DATA_WAREHOUSE = auto()
 
 
 # Class(es)

--- a/run_jobs.py
+++ b/run_jobs.py
@@ -31,7 +31,7 @@ class Job:
         self.method_name: str = job_name.value.split('.')[-1]
         self.started_at: Union[int, None] = None
         self.finished_at: Union[int, None] = None
-        self.data_sources: Sequence[Dict[str, Union[str, pd.Timestamp]]] = []
+        self.data_sources: Sequence[Dict[str, Union[ValidDataSourceName, pd.Timestamp]]] = []
 
     def create_metadata(self) -> None:
         started_at_dt = pd.to_datetime(self.started_at, unit='s')
@@ -49,7 +49,13 @@ class Job:
         if len(self.data_sources) == 0:
             logger.warning('No valid data sources were identified')
         else:
-            data_source_status_df = pd.DataFrame(self.data_sources)
+            db_ready_data_sources = []
+            for data_source in self.data_sources:
+                db_ready_data_source = data_source.copy()
+                db_ready_data_source['data_source_name'] = db_ready_data_source['data_source_name'].name
+                db_ready_data_sources.append(db_ready_data_source)
+                
+            data_source_status_df = pd.DataFrame(db_ready_data_sources)
             data_source_status_df = data_source_status_df.assign(**{'job_run_id': job_run_id})
             data_source_status_df.to_sql('data_source_status', db_creator_obj.engine, if_exists='append', index=False)
             logger.info(f'Inserted {len(data_source_status_df)} data_source_status records')
@@ -69,11 +75,11 @@ class Job:
 
         valid_data_sources = []
         for data_source in data_sources:
-            data_source_name = data_source['data_source_name']
-            if data_source_name in ValidDataSourceName.__members__:
+            data_source_name_mem = data_source['data_source_name']
+            if isinstance(data_source_name_mem, ValidDataSourceName):
                 valid_data_sources.append(data_source)
             else:
-                logger.error(f'{data_source_name} is not a valid data source name')
+                logger.error(f'Received an invalid data source name: {data_source_name_mem}')
                 logger.error(f'No data_source_status record will be inserted.')
 
         self.data_sources = valid_data_sources
@@ -89,7 +95,7 @@ class JobManager:
                 job_name_mem = ValidJobName[job_name.upper()]
                 self.jobs.append(Job(job_name_mem))
             else:
-                logger.error(f'{job_name} is not a valid job name; it will be ignored')
+                logger.error(f'Received an invalid job name: {job_name}; it will be ignored')
 
     def run_jobs(self) -> None:
         for job in self.jobs:

--- a/vocab.py
+++ b/vocab.py
@@ -20,4 +20,3 @@ class ValidJobName(Enum):
 class ValidDataSourceName(Enum):
     CANVAS_API = auto()
     UNIZIN_DATA_WAREHOUSE = auto()
-    

--- a/vocab.py
+++ b/vocab.py
@@ -1,0 +1,23 @@
+# standard libraries
+from enum import auto, Enum
+
+
+# Enum(s)
+
+# Each job name should be defined in ValidJobName.
+# NAME_OF_JOB = 'path.to.method'
+
+class ValidJobName(Enum):
+    COURSE_INVENTORY = 'course_inventory.inventory.run_course_inventory'
+    # ONLINE_MEETINGS = 'online_meetings.report...'
+    # ZOOM = 'online_meetings.canvas_zoom_meetings...'
+    # MIVIDEO = 'mivideo...'
+
+
+# Each data source name should be defined in ValidDataSourceName.
+# NAME_OF_DATA_SOURCE = auto()
+
+class ValidDataSourceName(Enum):
+    CANVAS_API = auto()
+    UNIZIN_DATA_WAREHOUSE = auto()
+    

--- a/vocab.py
+++ b/vocab.py
@@ -4,19 +4,23 @@ from enum import auto, Enum
 
 # Enum(s)
 
-# Each job name should be defined in ValidJobName.
-# NAME_OF_JOB = 'path.to.method'
-
 class ValidJobName(Enum):
+    """
+    Each job name should be defined in ValidJobName.
+    NAME_OF_JOB = 'path.to.method'
+    """
+    
     COURSE_INVENTORY = 'course_inventory.inventory.run_course_inventory'
     # ONLINE_MEETINGS = 'online_meetings.report...'
     # ZOOM = 'online_meetings.canvas_zoom_meetings...'
     # MIVIDEO = 'mivideo...'
 
 
-# Each data source name should be defined in ValidDataSourceName.
-# NAME_OF_DATA_SOURCE = auto()
-
 class ValidDataSourceName(Enum):
+    """
+    Each data source name should be defined in ValidDataSourceName.
+    NAME_OF_DATA_SOURCE = auto()
+    """
+    
     CANVAS_API = auto()
     UNIZIN_DATA_WAREHOUSE = auto()


### PR DESCRIPTION
This PR pulls out the enumerations from `run_jobs.py` into a separate `vocab.py` module so that both `run_jobs.py` and job-specific modules can reference the enumeration without introducing a circular dependency. It also changes the format of the `data_source` dictionaries returned from job entry functions so that the value associated with the key `data_source_name` is a member of `ValidDataSourceName`. This PR aims to resolve #96.