### PR TITLE
Identify and pull canvasdatadate using key name and value column (#103)

### DIFF
--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -245,8 +245,12 @@ def run_course_inventory() -> Sequence[Dict[str, Union[ValidDataSourceName, pd.T
     section_df = pd.merge(section_df, sis_section_df, on='canvas_id', how='left')
 
     # Record data source info for UDW
-    udw_meta_df = pd.read_sql('SELECT * FROM unizin_metadata;', udw_conn)
-    udw_update_datetime_str = udw_meta_df[udw_meta_df['key'] == 'canvasdatadate']['value'].iloc[0]
+    udw_meta_df = pd.read_sql('''
+        SELECT *
+        FROM unizin_metadata
+        WHERE key='canvasdatadate';
+    ''', udw_conn)
+    udw_update_datetime_str = udw_meta_df['value'].iloc[0]
     udw_update_datetime = pd.to_datetime(udw_update_datetime_str, format='%Y-%m-%d %H:%M:%S.%f%z')
     logger.info(f'Found canvasdatadate in UDW of {udw_update_datetime}')
 

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -246,7 +246,7 @@ def run_course_inventory() -> Sequence[Dict[str, Union[ValidDataSourceName, pd.T
 
     # Record data source info for UDW
     udw_meta_df = pd.read_sql('SELECT * FROM unizin_metadata;', udw_conn)
-    udw_update_datetime_str = udw_meta_df.iloc[1, 1]
+    udw_update_datetime_str = udw_meta_df[udw_meta_df['key'] == 'canvasdatadate']['value'].iloc[0]
     udw_update_datetime = pd.to_datetime(udw_update_datetime_str, format='%Y-%m-%d %H:%M:%S.%f%z')
     logger.info(f'Found canvasdatadate in UDW of {udw_update_datetime}')
 


### PR DESCRIPTION
This PR makes a small change that aims to avoid errors by moving from a hardcoded-index-based approach to a name-based approach for identifying and pulling the `canvasdatadate` value from the UDW's `unizin_metadata` table. This PR aims to resolve issue #103.