### PR TITLE
Move sleep until after MySQL container check (#105)

### DIFF
--- a/run_jobs.py
+++ b/run_jobs.py
@@ -111,8 +111,8 @@ if __name__ == '__main__':
     if how_started == 'DOCKER_COMPOSE':
         # Wait for MySQL container to finish setting up
         # If it's not ready in two minutes, exit
-        num_loops = 41
-        for i in range(1, num_loops + 1):
+        num_loops = 40
+        for i in range(num_loops + 1):
             try:
                 db_creator_obj.set_up()
                 db_creator_obj.tear_down()
@@ -123,12 +123,11 @@ if __name__ == '__main__':
                     logger.error('MySQL was not available')
                     sys.exit(1)
                 else:
-                    if i == 1:
+                    if i == 0:
                         logger.info('Waiting for the MySQL snail')
                     else:
                         logger.debug('Still waiting!')
                     time.sleep(3.0)
-
 
     # Apply any new migrations
     logger.info('Applying any new migrations')

--- a/run_jobs.py
+++ b/run_jobs.py
@@ -110,11 +110,9 @@ if __name__ == '__main__':
 
     if how_started == 'DOCKER_COMPOSE':
         # Wait for MySQL container to finish setting up
-        logger.info('Waiting for the MySQL snail')
         # If it's not ready in two minutes, exit
-        num_loops = 40
+        num_loops = 41
         for i in range(1, num_loops + 1):
-            time.sleep(3.0)
             try:
                 db_creator_obj.set_up()
                 db_creator_obj.tear_down()
@@ -125,7 +123,12 @@ if __name__ == '__main__':
                     logger.error('MySQL was not available')
                     sys.exit(1)
                 else:
-                    logger.debug('Still waiting!')
+                    if i == 1:
+                        logger.info('Waiting for the MySQL snail')
+                    else:
+                        logger.debug('Still waiting!')
+                    time.sleep(3.0)
+
 
     # Apply any new migrations
     logger.info('Applying any new migrations')


### PR DESCRIPTION
This PR modifies the sleep mechanism for use with `docker-compose` so that the database check happens before the `time.sleep(1)`. The PR aims to resolves #105.