### PR TITLE
Improve DBCreator (#66, #84, #109)

### DIFF
--- a/config/env_blank.json
+++ b/config/env_blank.json
@@ -42,7 +42,6 @@
     "password": ""
   },
   "APPEND_TABLE_NAMES": [
-    "job_run", "data_source_status",
     "mivideo_media_started_hourly"
   ]
 }

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -104,7 +104,7 @@ def gather_course_data_from_api(account_id: int, term_id: int) -> pd.DataFrame:
     course_dicts = slim_down_course_data(all_course_data)
     more_pages = True
 
-    while more_pages:
+    while more_pages and page_num < 2:
         next_params = API_UTIL.get_next_page(response)
         if next_params:
             page_num += 1
@@ -291,9 +291,7 @@ def run_course_inventory() -> Sequence[Dict[str, Union[ValidDataSourceName, pd.T
     # Empty tables (if any) in database, then migrate
     logger.info('Emptying tables in DB')
     db_creator_obj = DBCreator(INVENTORY_DB, APPEND_TABLE_NAMES)
-    db_creator_obj.set_up()
-    db_creator_obj.drop_records()
-    db_creator_obj.tear_down()
+    db_creator_obj.connect().drop_records().close()
 
     # Insert gathered data
     logger.info(f'Inserting {num_course_records} course records to DB')

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -104,7 +104,7 @@ def gather_course_data_from_api(account_id: int, term_id: int) -> pd.DataFrame:
     course_dicts = slim_down_course_data(all_course_data)
     more_pages = True
 
-    while more_pages and page_num < 2:
+    while more_pages:
         next_params = API_UTIL.get_next_page(response)
         if next_params:
             page_num += 1

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -104,7 +104,7 @@ def gather_course_data_from_api(account_id: int, term_id: int) -> pd.DataFrame:
     course_dicts = slim_down_course_data(all_course_data)
     more_pages = True
 
-    while more_pages:
+    while more_pages and page_num < 2:
         next_params = API_UTIL.get_next_page(response)
         if next_params:
             page_num += 1
@@ -291,7 +291,7 @@ def run_course_inventory() -> Sequence[Dict[str, Union[ValidDataSourceName, pd.T
     # Empty tables (if any) in database, then migrate
     logger.info('Emptying tables in DB')
     db_creator_obj = DBCreator(INVENTORY_DB, APPEND_TABLE_NAMES)
-    db_creator_obj.connect().drop_records().close()
+    db_creator_obj.drop_records()
 
     # Insert gathered data
     logger.info(f'Inserting {num_course_records} course records to DB')

--- a/create_db.py
+++ b/create_db.py
@@ -10,7 +10,7 @@ from environ import ENV
 logger = logging.getLogger(__name__)
 
 DB_PARAMS = ENV['INVENTORY_DB']
-APPEND_TABLE_NAMES = ENV.get('APPEND_TABLE_NAMES', ['job_run'])
+APPEND_TABLE_NAMES = ENV.get('APPEND_TABLE_NAMES', [])
 
 
 # Main Program

--- a/db/db_creator.py
+++ b/db/db_creator.py
@@ -1,10 +1,13 @@
+# This is needed for type hinting with fluent interfaces
+from __future__ import annotations
+
 # standard libraries
 import logging, os
-from typing import Dict, Sequence
+from typing import Dict, List, Sequence, Union
 from urllib.parse import quote_plus
 
 # third-party libraries
-from sqlalchemy.engine import create_engine
+from sqlalchemy.engine import create_engine, Connection, Engine
 from yoyo import get_backend, read_migrations
 
 logger = logging.getLogger(__name__)
@@ -12,18 +15,21 @@ logger = logging.getLogger(__name__)
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 MIGRATIONS_PATH = os.path.join(ROOT_DIR, 'migrations')
 
+# The metadata tables are append tables by default.
+DEFAULT_APPEND_TABLES = ['job_run', 'data_source_status']
+
 
 class DBCreator:
 
     def __init__(
         self,
         db_params: Dict[str, str],
-        append_table_names: Sequence[str] = []
+        append_table_names: List[str] = []
     ) -> None:
 
-        self.db_name = db_params['dbname']
-        self.conn = None
-        self.conn_str = (
+        self.db_name: str = db_params['dbname']
+        self.conn: Union[Connection, None] = None
+        self.conn_str: str = (
             'mysql+mysqldb' +
             f"://{db_params['user']}" +
             f":{quote_plus(db_params['password'])}" +
@@ -31,40 +37,48 @@ class DBCreator:
             f":{db_params['port']}" +
             f"/{db_params['dbname']}?charset=utf8&ssl=true"
         )
-        self.engine = create_engine(self.conn_str)
-        self.append_table_names = append_table_names
+        self.engine: Engine = create_engine(self.conn_str)
+        self.append_table_names: List[str] = append_table_names + DEFAULT_APPEND_TABLES
 
-    def set_up(self) -> None:
+    def connect(self) -> DBCreator:
         logger.debug('set_up')
         self.conn = self.engine.connect()
+        return self
 
-    def tear_down(self) -> None:
+    def close(self) -> DBCreator:
         logger.debug('tear_down')
-        self.conn.close()
+        if not isinstance(self.conn, Connection):
+            logger.error('self.conn needs to be initalized before it can be closed')
+        else:
+            self.conn.close()
+        return self
 
     def get_table_names(self) -> Sequence[str]:
         logger.debug('get_table_names')
         return self.engine.table_names()
 
-    def migrate(self) -> None:
+    def migrate(self) -> DBCreator:
         logger.debug('migrate')
         backend = get_backend(self.conn_str)
         migrations = read_migrations(MIGRATIONS_PATH)
         with backend.lock():
             backend.apply_migrations(backend.to_apply(migrations))
+        return self
 
-    def drop_records(self) -> None:
+    def drop_records(self) -> DBCreator:
         logger.debug('drop_records')
-        self.conn.execute('SET FOREIGN_KEY_CHECKS=0;')
-        for table_name in self.get_table_names():
-            if 'yoyo' not in table_name and table_name not in self.append_table_names:
-                logger.debug(f'Table Name: {table_name}')
-                self.conn.execute(f'DELETE FROM {table_name};')
-                logger.info(f'Dropped records in {table_name} in {self.db_name}')
-        self.conn.execute('SET FOREIGN_KEY_CHECKS=1;')
+        if not isinstance(self.conn, Connection):
+            logger.error('self.conn needs to be initalized first before it can be used')
+        else:
+            self.conn.execute('SET FOREIGN_KEY_CHECKS=0;')
+            for table_name in self.get_table_names():
+                if 'yoyo' not in table_name and table_name not in self.append_table_names:
+                    logger.debug(f'Table Name: {table_name}')
+                    self.conn.execute(f'DELETE FROM {table_name};')
+                    logger.info(f'Dropped records in {table_name} in {self.db_name}')
+            self.conn.execute('SET FOREIGN_KEY_CHECKS=1;')
+        return self
 
-    def set_up_database(self) -> None:
-        self.set_up()
-        self.drop_records()
-        self.migrate()
-        self.tear_down()
+    def set_up_database(self) -> DBCreator:
+        self.connect().drop_records().close().migrate()
+        return self

--- a/db/db_creator.py
+++ b/db/db_creator.py
@@ -19,7 +19,7 @@ PARENT_PATH = os.path.dirname(os.path.abspath(__file__))
 MIGRATIONS_PATH = os.path.join(PARENT_PATH, 'migrations')
 
 # The metadata tables are append tables by default.
-DEFAULT_APPEND_TABLES = ['job_run', 'data_source_status']
+DEFAULT_APPEND_TABLE_NAMES = ['job_run', 'data_source_status']
 
 
 class DBCreator:
@@ -42,7 +42,7 @@ class DBCreator:
         self.engine: Engine = create_engine(self.conn_str)
 
         self.append_table_names: List[str] = append_table_names
-        self.append_table_names += DEFAULT_APPEND_TABLES
+        self.append_table_names += DEFAULT_APPEND_TABLE_NAMES
 
     def get_table_names(self) -> List[str]:
         logger.debug('get_table_names')

--- a/db/db_creator.py
+++ b/db/db_creator.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 # standard libraries
 import logging, os
-from typing import Dict, List, Union
+from typing import Dict, List
 from urllib.parse import quote_plus
 
 # third-party libraries
-from sqlalchemy.engine import create_engine, Connection, Engine
+from sqlalchemy.engine import create_engine, Engine
 from yoyo import get_backend, read_migrations
 
 

--- a/db/db_creator.py
+++ b/db/db_creator.py
@@ -31,7 +31,6 @@ class DBCreator:
     ) -> None:
 
         self.db_name: str = db_params['dbname']
-        self.conn: Union[Connection, None] = None
         self.conn_str: str = (
             'mysql+mysqldb' +
             f"://{db_params['user']}" +

--- a/mivideo/mivideo_extract.py
+++ b/mivideo/mivideo_extract.py
@@ -57,12 +57,11 @@ class MiVideoExtract(object):
         logger.info(f'Connected to BigQuery project: "{self.udpDb.project}"')
 
         dbParams: Dict = ENV['INVENTORY_DB']
-        appendTableNames: Sequence[str] = ENV.get('APPEND_TABLE_NAMES', [
-            'job_run', 'data_source_status', 'mivideo_media_started_hourly',
-            'mivideo_media_creation'])
+        appendTableNames: Sequence[str] = ENV.get(
+            'APPEND_TABLE_NAMES', ['mivideo_media_started_hourly']
+        )
 
         self.appDb: DBCreator = DBCreator(dbParams, appendTableNames)
-        self.appDb.set_up()
 
     def _readTableLastTime(self, tableName: str, tableColumnName: str) -> Union[datetime, None]:
         lastTime: Union[datetime, None]

--- a/run_jobs.py
+++ b/run_jobs.py
@@ -116,8 +116,8 @@ if __name__ == '__main__':
         num_loops = 40
         for i in range(num_loops + 1):
             try:
-                db_creator_obj.set_up()
-                db_creator_obj.tear_down()
+                conn = db_creator_obj.engine.connect()
+                conn.close()
                 logger.info('MySQL caught up')
                 break
             except sqlalchemy.exc.OperationalError:


### PR DESCRIPTION
This PR makes changes to `DBCreator`, and usages, to resolve a few issues that have accumulated related to the class. The issues and how they were resolved are described below in the task list. The PR aims to resolve issues #66, #84, and #109.

- [x] Add `DEFAULT_APPEND_TABLE_NAMES` to the `db_creator` module, and update references to `APPEND_TABLE_NAMES`, so that the metadata tables don't have to be specified in the config. (issue #66)
- [x] Implement a fluent interface for `DBCreator`, which was requested by @lsloan (issue #84).
- [x] Remove `self.conn`, `self.set_up`, and `self.tear_down` from `DBCreator` class (these just caused confusion and really we can use the SQLAlchemy API off of `self.engine` for creating and dispensing with connection objects as needed) (issue #109).