### PR TITLE
fix MiVideo `data_updated_at` timestamp (#111)

### DIFF
--- a/mivideo/mivideo_extract.py
+++ b/mivideo/mivideo_extract.py
@@ -125,7 +125,7 @@ class MiVideoExtract(object):
 
         return [{
             'data_source_name': ValidDataSourceName.UNIZIN_DATA_PLATFORM_EVENTS,
-            'data_updated_at': pd.to_datetime(time.time(), unit='s', utc=True)
+            'data_updated_at': pd.to_datetime(time.time(), utc=True)
         }]
 
 

--- a/mivideo/mivideo_extract.py
+++ b/mivideo/mivideo_extract.py
@@ -125,7 +125,7 @@ class MiVideoExtract(object):
 
         return [{
             'data_source_name': ValidDataSourceName.UNIZIN_DATA_PLATFORM_EVENTS,
-            'data_updated_at': pd.to_datetime(time.time(), utc=True)
+            'data_updated_at': pd.to_datetime(time.time(), unit='s', utc=True)
         }]
 
 


### PR DESCRIPTION
Fixes #111.

Specify the units of the source timestamp so Pandas will convert it to a string representation correctly.