### PR TITLE
Add term table, accomodate multiple terms, fix course.sis_id bug (#113, #117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ This includes the creation of a configuration file called `env.json`. Complete t
     `LOG_LEVEL` | The minimum level for log messages that will appear in output. `INFO` or `DEBUG` is recommended for most use cases; see [Python's logging module](https://docs.python.org/3/library/logging.html).
     `JOB_NAMES` | The names of one or more jobs (not case sensitive) that have been implemented and defined in `run_jobs.py` (see the **Implementing a New Job** section below).
     `CANVAS_ACCOUNT_ID` | The Canvas instance root account ID number associated with the courses for which data will be collected.
-    `CANVAS_TERM_IDS` | The Canvas instance term ID numbers that will be used to limit queries for Canvas courses. Set to `[0]` to use `ADD_COURSE_IDS`.
-    `ADD_COURSE_IDS` | Additional Canvas course IDs to retrieve. Duplicates found in `CANVAS_TERM_ID` (if defined) will be removed.
+    `CANVAS_TERM_IDS` | The Canvas instance term ID numbers that will be used to limit queries for Canvas courses. Set to `[]` (empty array) to only use `ADD_COURSE_IDS` (see below).
+    `ADD_COURSE_IDS` | Additional Canvas course IDs to retrieve when using `online_meetings/canvas_zoom_meetings.py`. Duplicates found in `CANVAS_TERM_ID` (if defined) will be removed.
     `API_BASE_URL` | The base URL for making requests using the U-M API Directory; the default value should be correct.
     `API_SCOPE_PREFIX` | The scope prefix that will be added after the `API_BASE_URL`; this is usually an acronym for the university location and the API Directory subscription name in CamelCase, separated by `/`.
     `API_SUBSCRIPTION_NAME` | The name of the API Directory subscription all in lowercase.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This includes the creation of a configuration file called `env.json`. Complete t
     `LOG_LEVEL` | The minimum level for log messages that will appear in output. `INFO` or `DEBUG` is recommended for most use cases; see [Python's logging module](https://docs.python.org/3/library/logging.html).
     `JOB_NAMES` | The names of one or more jobs (not case sensitive) that have been implemented and defined in `run_jobs.py` (see the **Implementing a New Job** section below).
     `CANVAS_ACCOUNT_ID` | The Canvas instance root account ID number associated with the courses for which data will be collected.
-    `CANVAS_TERM_ID` | The Canvas instance term ID number that will be used to limit the query for Canvas courses. Set to 0 to use `ADD_COURSE_IDS`.
+    `CANVAS_TERM_IDS` | The Canvas instance term ID numbers that will be used to limit queries for Canvas courses. Set to `[0]` to use `ADD_COURSE_IDS`.
     `ADD_COURSE_IDS` | Additional Canvas course IDs to retrieve. Duplicates found in `CANVAS_TERM_ID` (if defined) will be removed.
     `API_BASE_URL` | The base URL for making requests using the U-M API Directory; the default value should be correct.
     `API_SCOPE_PREFIX` | The scope prefix that will be added after the `API_BASE_URL`; this is usually an acronym for the university location and the API Directory subscription name in CamelCase, separated by `/`.

--- a/config/env_blank.json
+++ b/config/env_blank.json
@@ -44,7 +44,6 @@
   "APPEND_TABLE_NAMES": [
     "job_run", 
     "data_source_status",
-    "term",
     "mivideo_media_started_hourly"
   ]
 }

--- a/config/env_blank.json
+++ b/config/env_blank.json
@@ -2,7 +2,7 @@
   "LOG_LEVEL": "DEBUG",
   "JOB_NAMES": ["COURSE_INVENTORY"],
   "CANVAS_ACCOUNT_ID": 1,
-  "CANVAS_TERM_ID": 164,
+  "CANVAS_TERM_IDS": [164],
   "ADD_COURSE_IDS": [],
   "API_BASE_URL": "https://apigw.it.umich.edu/um",
   "API_SCOPE_PREFIX": "",
@@ -42,7 +42,9 @@
     "password": ""
   },
   "APPEND_TABLE_NAMES": [
-    "job_run", "data_source_status",
+    "job_run", 
+    "data_source_status",
+    "term",
     "mivideo_media_started_hourly"
   ]
 }

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -343,7 +343,7 @@ def run_course_inventory() -> Sequence[Dict[str, Union[ValidDataSourceName, pd.T
     # Initialize DBCreator object
     db_creator_obj = DBCreator(INVENTORY_DB, APPEND_TABLE_NAMES)
 
-    # Empty tables (if any) in database, then migrate
+    # Empty tables (if any) in database
     logger.info('Emptying tables in DB')
     db_creator_obj.set_up()
     db_creator_obj.drop_records()

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -74,26 +74,29 @@ def gather_new_term_data_from_api(
 ) -> pd.DataFrame:
 
     logger.info('** gather_new_term_data_from_api')
+
     # Find terms that don't already have records
     term_df = pd.read_sql('term', creator_obj.engine)
-    logger.debug(term_df.head(25))
-
     new_term_ids = [
-        term_id for term_id in term_ids if term_id not in term_df['canvas_id'].to_list()
+        term_id for term_id in term_ids
+        if term_id not in term_df['canvas_id'].to_list()
     ]
+
     if len(new_term_ids) == 0:
-        logger.info('No new term IDS were found; returning empty DataFrame')
+        logger.info('No new term IDs were found; returning empty DataFrame')
         return pd.DataFrame({})
     else:
         logger.info(f'Found new term ID(s) in config: {new_term_ids}')
-        # Fetch new terms
+
+        # Fetch data for new terms
         url_ending_with_scope = f'{API_SCOPE_PREFIX}/accounts/{account_id}/terms/'
 
         new_term_dicts = []
         for new_term_id in new_term_ids:
-            term_url_ending = url_ending_with_scope + str(new_term_id)
             logger.info(f'Pulling data for Canvas term number {new_term_id}')
+            term_url_ending = url_ending_with_scope + str(new_term_id)
             response = make_request_using_api_utils(term_url_ending)
+
             term_dict = json.loads(response.text)
             new_slim_term_dict = {
                 'canvas_id': term_dict['id'],
@@ -109,8 +112,9 @@ def gather_new_term_data_from_api(
                 )
             }
             new_term_dicts.append(new_slim_term_dict)
+
         new_term_df = pd.DataFrame(new_term_dicts)
-        logger.debug(new_term_df)
+        logger.debug(new_term_df.head())
         return new_term_df
 
 
@@ -141,7 +145,7 @@ def gather_course_data_from_api(account_id: int, term_ids: Sequence[int]) -> pd.
 
     course_dicts = []
     for term_id in term_ids:
-        logger.info(f'Processing term {term_id}')
+        logger.info(f'Fetching course data for term {term_id}')
 
         params = {
             'with_enrollments': True,

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -107,7 +107,7 @@ def gather_new_term_data_from_api(
                     format=CANVAS_DATETIME_FORMAT
                 ),
                 'end_at': pd.to_datetime(
-                    term_dict['start_at'],
+                    term_dict['end_at'],
                     format=CANVAS_DATETIME_FORMAT
                 )
             }

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -67,7 +67,7 @@ def make_request_using_api_utils(url: str, params: Dict[str, Any] = {}) -> Respo
     return response
 
 
-def gather_new_term_data_from_api(account_id: int, term_ids: Sequence[int]) -> pd.DataFrame:
+def gather_term_data_from_api(account_id: int, term_ids: Sequence[int]) -> pd.DataFrame:
     logger.info('** gather_new_term_data_from_api')
 
     # Fetch data for terms from config
@@ -229,7 +229,7 @@ def run_course_inventory() -> Sequence[Dict[str, Union[ValidDataSourceName, pd.T
     logger.info('Making requests against the Canvas API')
 
     # Gather term data
-    term_df = gather_new_term_data_from_api(ACCOUNT_ID, TERM_IDS)
+    term_df = gather_term_data_from_api(ACCOUNT_ID, TERM_IDS)
 
     # Gather course data
     course_df = gather_course_data_from_api(ACCOUNT_ID, TERM_IDS)

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -248,7 +248,7 @@ def run_course_inventory() -> Sequence[Dict[str, Union[ValidDataSourceName, pd.T
 
     logger.info('Making requests against the Canvas API')
 
-    # Gather new_term_data
+    # Gather new term data
     new_term_df = gather_new_term_data_from_api(ACCOUNT_ID, TERM_IDS, db_creator_obj)
 
     # Gather course data

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -123,7 +123,7 @@ def slim_down_course_data(course_data: List[Dict]) -> List[Dict]:
     for course_dict in course_data:
         slim_course_dict = {
             'canvas_id': course_dict['id'],
-            'sis_id': course_dict['sis_course_id'],
+            'sis_id': str(course_dict['sis_course_id']),
             'name': course_dict['name'],
             'account_id': course_dict['account_id'],
             'term_id': course_dict['enrollment_term_id'],

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -11,13 +11,13 @@ from requests import Response
 from umich_api.api_utils import ApiUtil
 
 # local libraries
-from db.db_creator import DBCreator
-from environ import ENV
-from vocab import ValidDataSourceName
 from course_inventory.async_enroll_gatherer import AsyncEnrollGatherer
 from course_inventory.canvas_course_usage import CanvasCourseUsage
 from course_inventory.gql_queries import queries as QUERIES
 from course_inventory.published_date import FetchPublishedDate
+from db.db_creator import DBCreator
+from environ import ENV
+from vocab import ValidDataSourceName
 
 
 # Initialize settings and globals

--- a/db/migrations/0013.add_term_table.py
+++ b/db/migrations/0013.add_term_table.py
@@ -19,7 +19,7 @@ steps = [
     '''),
     step('''
         ALTER TABLE course
-        ADD COLUMN term_id INTEGER NULL AFTER account_id;
+        ADD COLUMN term_id INTEGER NOT NULL AFTER account_id;
     '''),
     step('''
         ALTER TABLE course

--- a/db/migrations/0013.add_term_table.py
+++ b/db/migrations/0013.add_term_table.py
@@ -1,0 +1,31 @@
+#
+# file: migrations/0013.add_term_table.py
+#
+from yoyo import step
+
+steps = [
+    step('''
+        CREATE TABLE IF NOT EXISTS term
+        (
+            canvas_id INTEGER NOT NULL UNIQUE,
+            name VARCHAR(100) NOT NULL UNIQUE,
+            sis_id INTEGER NOT NULL,
+            start_at DATETIME NOT NULL,
+            end_at DATETIME NOT NULL,
+            PRIMARY KEY (canvas_id)
+        )
+        ENGINE=InnoDB
+        CHARACTER SET utf8mb4;
+    '''),
+    step('''
+        ALTER TABLE course
+        ADD COLUMN term_id INTEGER NULL AFTER account_id;
+    '''),
+    step('''
+        ALTER TABLE course
+        ADD CONSTRAINT fk_term_id
+            FOREIGN KEY (term_id)
+            REFERENCES term(canvas_id)
+            ON UPDATE CASCADE ON DELETE CASCADE;
+    ''')
+]

--- a/db/migrations/0014.change_course_sis_id_data_type.py
+++ b/db/migrations/0014.change_course_sis_id_data_type.py
@@ -1,0 +1,10 @@
+#
+# file: migrations/0014.change_course_sis_id_data_type.py
+#
+from yoyo import step
+
+step('''
+    ALTER TABLE course
+    MODIFY
+        sis_id VARCHAR(15) NULL;
+''')

--- a/online_meetings/canvas_zoom_meetings.py
+++ b/online_meetings/canvas_zoom_meetings.py
@@ -160,7 +160,7 @@ class ZoomPlacements:
                 self.get_zoom_details(posturl, formdata, course.id)
         return None
 
-    def zoom_course_report(self, canvas_account: int = 1, enrollment_term_ids: Sequence[int] = [0],
+    def zoom_course_report(self, canvas_account: int = 1, enrollment_term_ids: Sequence[int] = [],
                            published: bool = True, add_course_ids: list = None) -> None:
 
         account = CANVAS.get_account(canvas_account)
@@ -169,7 +169,7 @@ class ZoomPlacements:
 
         # Get all published courses from the defined enrollment terms
         courses = []
-        if enrollment_term_ids:
+        if len(enrollment_term_ids) > 0:
             for enrollment_term_id in enrollment_term_ids:
                 list_of_courses = list(
                     account.get_courses(
@@ -203,7 +203,7 @@ class ZoomPlacements:
 start_time = datetime.now()
 logger.info(f"Script started at {start_time}")
 zoom_placements = ZoomPlacements()
-zoom_placements.zoom_course_report(ENV.get("CANVAS_ACCOUNT_ID", 1), ENV.get("CANVAS_TERM_IDS", [0]),
+zoom_placements.zoom_course_report(ENV.get("CANVAS_ACCOUNT_ID", 1), ENV.get("CANVAS_TERM_IDS", []),
                                    True, ENV.get("ADD_COURSE_IDS", []))
 
 zoom_courses_df = pd.DataFrame(zoom_placements.zoom_courses)

--- a/online_meetings/canvas_zoom_meetings.py
+++ b/online_meetings/canvas_zoom_meetings.py
@@ -160,8 +160,13 @@ class ZoomPlacements:
                 self.get_zoom_details(posturl, formdata, course.id)
         return None
 
-    def zoom_course_report(self, canvas_account: int = 1, enrollment_term_ids: Sequence[int] = [],
-                           published: bool = True, add_course_ids: list = None) -> None:
+    def zoom_course_report(
+        self,
+        canvas_account: int = 1,
+        enrollment_term_ids: Sequence[int] = [],
+        published: bool = True,
+        add_course_ids: list = None
+    ) -> None:
 
         account = CANVAS.get_account(canvas_account)
         # Canvas has a limit of 100 per page on this API
@@ -171,14 +176,14 @@ class ZoomPlacements:
         courses = []
         if len(enrollment_term_ids) > 0:
             for enrollment_term_id in enrollment_term_ids:
-                list_of_courses = list(
+                courses_list = list(
                     account.get_courses(
                         enrollment_term_id=enrollment_term_id,
                         published=published,
                         per_page=per_page
                     )
                 )
-                courses += list_of_courses
+                courses += courses_list
 
         course_count = 0
         for course in courses:

--- a/online_meetings/canvas_zoom_meetings.py
+++ b/online_meetings/canvas_zoom_meetings.py
@@ -7,7 +7,7 @@ import os
 import re
 import sys
 from datetime import datetime
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Union
 
 import canvasapi
 import pandas as pd
@@ -163,7 +163,7 @@ class ZoomPlacements:
     def zoom_course_report(
         self,
         canvas_account: int = 1,
-        enrollment_term_ids: Sequence[int] = [],
+        enrollment_term_ids: Union[Sequence[int], None] = None,
         published: bool = True,
         add_course_ids: list = None
     ) -> None:
@@ -174,7 +174,7 @@ class ZoomPlacements:
 
         # Get all published courses from the defined enrollment terms
         courses = []
-        if len(enrollment_term_ids) > 0:
+        if enrollment_term_ids is not None:
             for enrollment_term_id in enrollment_term_ids:
                 courses_list = list(
                     account.get_courses(

--- a/online_meetings/canvas_zoom_meetings.py
+++ b/online_meetings/canvas_zoom_meetings.py
@@ -176,6 +176,7 @@ class ZoomPlacements:
         courses = []
         if enrollment_term_ids is not None:
             for enrollment_term_id in enrollment_term_ids:
+                logger.info(f'Fetching published course data for term {enrollment_term_id}')
                 courses_list = list(
                     account.get_courses(
                         enrollment_term_id=enrollment_term_id,

--- a/online_meetings/canvas_zoom_meetings.py
+++ b/online_meetings/canvas_zoom_meetings.py
@@ -180,9 +180,6 @@ class ZoomPlacements:
                 )
                 courses += list_of_courses
 
-        logger.info('Number of courses')
-        logger.info(len(courses))
-
         course_count = 0
         for course in courses:
             course_count += 1


### PR DESCRIPTION
This PR modifies the `COURSE_INVENTORY`job and the database schema as to be able to collect and store data related to multiple academic terms. Some additional details are provided in the task list below. This PR aims to resolve issues #113 and #117.

- [x] Add migration with new `term` table and with a `term_id` column and foreign key constraint to the `course` table.
- [x] Make `CANVAS_TERM_ID` configuration variable plural, i.e. `CANVAS_TERM_IDS`.
- [x] Add function that pulls data for terms specified in the config.
- [x] Modify `get_course_data_from_api` function to accept multiple terms, nest fetching process inside`for` loop, and then combine all results into one `course_df` (ensuring that future processes will consider courses from the multiple terms specified).
- [x] Write contents of `term_df` to database.
- [x] Add migration changing the data type of `course.sis_id` to `VARCHAR(15)` and type coercion to string of those values (see issue #117 for details).
- [x] Update `online_meetings/canvas_zoom_meetings.py` to handle multiple terms.
- [x] Update README.
