### PR TITLE
Switch to using sentinel values for two parameters in db_creator, inventory (#120)

### DIFF
--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -42,12 +42,17 @@ APPEND_TABLE_NAMES = ENV.get('APPEND_TABLE_NAMES', ['job_run', 'data_source_stat
 
 # Function(s) - Canvas
 
-def make_request_using_api_utils(url: str, params: Dict[str, Any] = {}) -> Response:
+def make_request_using_api_utils(url: str, params: Union[Dict[str, Any], None] = None) -> Response:
+    if params is None:
+        request_params = {}
+    else:
+        request_params = params
+
     logger.debug('Making a request for data...')
 
     for i in range(1, MAX_REQ_ATTEMPTS + 1):
         logger.debug(f'Attempt #{i}')
-        response = API_UTIL.api_call(url, SUBSCRIPTION_NAME, payload=params)
+        response = API_UTIL.api_call(url, SUBSCRIPTION_NAME, payload=request_params)
         status_code = response.status_code
 
         if status_code != 200:

--- a/db/db_creator.py
+++ b/db/db_creator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 # standard libraries
 import logging, os
-from typing import Dict, List
+from typing import Dict, List, Union
 from urllib.parse import quote_plus
 
 # third-party libraries
@@ -27,7 +27,7 @@ class DBCreator:
     def __init__(
         self,
         db_params: Dict[str, str],
-        append_table_names: List[str] = []
+        append_table_names: Union[List[str], None] = None
     ) -> None:
 
         self.db_name: str = db_params['dbname']
@@ -41,8 +41,9 @@ class DBCreator:
         )
         self.engine: Engine = create_engine(self.conn_str)
 
-        self.append_table_names: List[str] = append_table_names
-        self.append_table_names += DEFAULT_APPEND_TABLE_NAMES
+        self.append_table_names: List[str] = DEFAULT_APPEND_TABLE_NAMES
+        if append_table_names is not None:
+            self.append_table_names += append_table_names
 
     def get_table_names(self) -> List[str]:
         logger.debug('get_table_names')


### PR DESCRIPTION
This PR modifies two existing parameters in the constructor of `DBCreator` and the function `make_request_using_api_utils` from `course_inventory/inventory` to avoid the default mutable parameter value anti-pattern described [here](https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html) and flagged by Codacy. These changes do not appear to have any downstream effects on data produced. The PR aims to resolve issue #120.