### PR TITLE
Update requirements.txt (#139)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,13 @@
+beautifulsoup4==4.8.2
+canvasapi==0.15.0
+google-cloud-bigquery==1.24.0
 hjson==3.0.1
 jsonschema==3.2.0
 mysqlclient==1.4.6
-pandas==1.0.1
-psycopg2-binary==2.8.4
-SQLAlchemy==1.3.15
+pandas==1.0.3
+psycopg2-binary==2.8.5
+requests==2.22.0
+requests-futures==1.0.0
+SQLAlchemy==1.3.16
 -e git+https://github.com/tl-its-umich-edu/api-utils-python@v1.3#egg=umich-api
 yoyo-migrations==7.0.2
-requests-futures==1.0.0
-
-canvasapi==0.15.0
-beautifulsoup4==4.8.2
-dateparser==0.7.4
-pyjwt==1.7.1
-pyyaml==5.3.1
-google-cloud-bigquery==1.24.0


### PR DESCRIPTION
This PR updates `requirements.txt` to remove dependencies no longer in use, bump versions for bugfix releases, pin `requests`, and alphabetize entries. More details are provided in the task list below. The PR aims to resolve issue #139.

- [x] Remove `pyyaml`, `pyjwt`, and `dateparser` (which were used in Zoom code, removed by PR #136).
- [x] Bump versions for `psycopg2-binary`, `pandas`, and `SQLAlchemy` to latest bugfix releases (I waited on `beautifulsoup4`, since that has a minor release that might require more testing; it's also still at `4.9.0`).
- [x] Add `requests` and pin to version `2.22.0`, which is compatible with `umich-api` (I was seeing a warning during the build; we'll need to update that in `api-utils-python` at some point).
- [x] Alphabetize entries and remove spacing.