### PR TITLE
Fix duplicate dropping in AsyncEnrollGatherer (#145)

### DIFF
--- a/course_inventory/async_enroll_gatherer.py
+++ b/course_inventory/async_enroll_gatherer.py
@@ -177,9 +177,9 @@ class AsyncEnrollGatherer:
         # Seems like we shouldn't have to drop duplicates for enrollments, but once one
         # duplicate broke the process
         enrollment_df = pd.DataFrame(enrollment_records)
-        enrollment_count = len(enrollment_df)
+        orig_enrollment_count = len(enrollment_df)
         enrollment_df = enrollment_df.drop_duplicates(subset=['canvas_id'], keep='last')
-        logger.info(f'{len(enrollment_df) - enrollment_count} enrollment records were dropped')
+        logger.info(f'{orig_enrollment_count - len(enrollment_df)} enrollment records were dropped')
 
         user_df = pd.DataFrame(user_records).drop_duplicates(subset=['canvas_id'], keep='last')
         section_df = pd.DataFrame(section_records).drop_duplicates(subset=['canvas_id'], keep='last')

--- a/course_inventory/async_enroll_gatherer.py
+++ b/course_inventory/async_enroll_gatherer.py
@@ -178,11 +178,11 @@ class AsyncEnrollGatherer:
         # duplicate broke the process
         enrollment_df = pd.DataFrame(enrollment_records)
         enrollment_count = len(enrollment_df)
-        enrollment_df = enrollment_df.drop_duplicates()
+        enrollment_df = enrollment_df.drop_duplicates(subset=['canvas_id'], keep='last')
         logger.info(f'{len(enrollment_df) - enrollment_count} enrollment records were dropped')
 
-        user_df = pd.DataFrame(user_records).drop_duplicates()
-        section_df = pd.DataFrame(section_records).drop_duplicates()
+        user_df = pd.DataFrame(user_records).drop_duplicates(subset=['canvas_id'], keep='last')
+        section_df = pd.DataFrame(section_records).drop_duplicates(subset=['canvas_id'], keep='last')
         return (enrollment_df, user_df, section_df)
 
     def gather(self) -> None:


### PR DESCRIPTION
This PR makes small modifications to the usages of [`pd.DataFrame.drop_duplicates`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.drop_duplicates.html) in `AsyncEnrollGatherer.generate_output()` to avoid the possibility of duplicate primary keys (which can occur if a name or other field changed during the process, resulting in two slightly different records before duplicates are dropped). This possibility was avoided with the use of `subset=['canvas_id']` as a parameter to `drop_duplicates`, which will mean that only `canvas_id` (the PK) is considered when identifying duplicates. In addition, to ensure the latest changes are kept, the parameter `keep='last'` was also added. These changes were made to `enrollment` and `section` as well as `user` out of an abundance of caution. The PR aims to resolve issue #145.