### PR TITLE
I156 better published date

### DIFF
--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -262,7 +262,7 @@ def run_course_inventory() -> Sequence[DataSourceStatus]:
     logger.info(f"Size of courses with available workflow state: {course_available_df.shape}")
 
     course_copy_df = course_df.copy(deep=True)
-    logger.info(f"Size of courses data from API routine:  {course_copy_df.shape}")
+    logger.info(f"Size of courses data from API routine: {course_copy_df.shape}")
     logger.info(f"""Size of Published courses from API:
                 {course_copy_df[(course_copy_df['workflow_state'] == 'available')].shape}""")
     course_from_db_df = get_course_info_from_DB(db_creator_obj)

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -259,7 +259,7 @@ def run_course_inventory() -> Sequence[DataSourceStatus]:
     # Gather course data
     course_df = gather_course_data_from_api(ACCOUNT_ID, TERM_IDS)
     course_available_df = course_df.loc[course_df.workflow_state == 'available'].copy(deep=True)
-    logger.info(f"Size of courses when workflow state available {course_available_df.shape}")
+    logger.info(f"Size of courses with available workflow state: {course_available_df.shape}")
 
     course_copy_df = course_df.copy(deep=True)
     logger.info(f"Size of courses data from API routine:  {course_copy_df.shape}")

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -266,7 +266,7 @@ def run_course_inventory() -> Sequence[DataSourceStatus]:
     logger.info(f"""Size of Published courses from API:
                 {course_copy_df[(course_copy_df['workflow_state'] == 'available')].shape}""")
     course_from_db_df = get_course_info_from_DB(db_creator_obj)
-    logger.info(f"Size of Published courses from DB with:  {course_from_db_df.shape}")
+    logger.info(f"Size of published courses from DB with: {course_from_db_df.shape}")
     published_date_in_db = course_from_db_df[(course_from_db_df['published_at'].notnull())].shape
     logger.info(f"Size of Published courses from DB with published date: {published_date_in_db}")
     course_copy_df = pd.merge(course_copy_df, course_from_db_df, on='canvas_id', how='left')

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -228,18 +228,17 @@ def pull_sis_section_data_from_udw(section_ids: Sequence[int], conn: connection)
     return udw_section_df
 
 
-def get_course_info_from_db(db_creator_obj: DBCreator) -> pd.DataFrame:
+def get_pub_course_info_from_db(db_creator_obj: DBCreator) -> pd.DataFrame:
     logger.info(f"Getting the course info from {db_creator_obj.db_name} database")
     course_from_db_df = pd.read_sql(f'''select canvas_id, published_at from course 
                             where workflow_state = 'available' ;''',
                                     db_creator_obj.engine)
-    logger.info(course_from_db_df.head())
     return course_from_db_df
 
 # Entry point for run_jobs.py
 
 
-def run_course_inventory() -> Sequence[Dict[str, Union[ValidDataSourceName, pd.Timestamp]]]:
+def run_course_inventory() -> Sequence[DataSourceStatus]:
     logger.info("* run_course_inventory")
     # Initialize DBCreator object
     db_creator_obj = DBCreator(INVENTORY_DB)
@@ -255,7 +254,7 @@ def run_course_inventory() -> Sequence[Dict[str, Union[ValidDataSourceName, pd.T
     logger.info(f"Size of courses with available workflow state: {course_available_df.shape}")
 
     course_copy_df = course_df.copy(deep=True)
-    course_from_db_df = get_course_info_from_db(db_creator_obj)
+    course_from_db_df = get_pub_course_info_from_db(db_creator_obj)
 
     fetch_publish_date = FetchPublishedDate(CANVAS_URL, CANVAS_TOKEN, NUM_ASYNC_WORKERS,
                                             course_copy_df, course_from_db_df, MAX_REQ_ATTEMPTS)

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -228,21 +228,13 @@ def pull_sis_section_data_from_udw(section_ids: Sequence[int], conn: connection)
     return udw_section_df
 
 
-def get_course_info_from_DB(db_creator_obj: DBCreator) -> pd.DataFrame:
+def get_course_info_from_db(db_creator_obj: DBCreator) -> pd.DataFrame:
     logger.info("getting the course info from Database")
     course_from_db_df = pd.read_sql(f'''select canvas_id, published_at from course 
                             where workflow_state = 'available' ;''',
-                            db_creator_obj.engine)
+                                    db_creator_obj.engine)
     logger.info(course_from_db_df.head())
     return course_from_db_df
-
-
-def get_course_from_db_without_pub_date(df) -> List[int]:
-    course_without_pub_date_df = df[df['published_at'].isnull()]
-    course_id_with_no_pub = course_without_pub_date_df['canvas_id'].tolist()
-    logger.info(f"Courses list from Database with out published date{len(course_id_with_no_pub)}: {course_id_with_no_pub}")
-    return course_id_with_no_pub
-
 
 # Entry point for run_jobs.py
 
@@ -265,7 +257,7 @@ def run_course_inventory() -> Sequence[DataSourceStatus]:
     logger.info(f"Size of courses data from API routine: {course_copy_df.shape}")
     logger.info(f"""Size of Published courses from API:
                 {course_copy_df[(course_copy_df['workflow_state'] == 'available')].shape}""")
-    course_from_db_df = get_course_info_from_DB(db_creator_obj)
+    course_from_db_df = get_course_info_from_db(db_creator_obj)
     logger.info(f"Size of published courses from DB with: {course_from_db_df.shape}")
     published_date_in_db = course_from_db_df[(course_from_db_df['published_at'].notnull())].shape
     logger.info(f"Size of published courses from DB with published date: {published_date_in_db}")

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -255,53 +255,17 @@ def run_course_inventory() -> Sequence[Dict[str, Union[ValidDataSourceName, pd.T
     logger.info(f"Size of courses with available workflow state: {course_available_df.shape}")
 
     course_copy_df = course_df.copy(deep=True)
-    logger.info(f"Size of courses data from API routine: {course_copy_df.shape}")
-    logger.info(f"""Size of Published courses from API:
-                {course_copy_df[(course_copy_df['workflow_state'] == 'available')].shape}""")
     course_from_db_df = get_course_info_from_db(db_creator_obj)
-    logger.info(f"Size of published courses from DB with: {course_from_db_df.shape}")
-    published_date_in_db = course_from_db_df[(course_from_db_df['published_at'].notnull())].shape
-    logger.info(f"Size of published courses from DB with published date: {published_date_in_db}")
-    course_copy_df = pd.merge(course_copy_df, course_from_db_df, on='canvas_id', how='left')
-    logger.info(f"Size of course data after merging from DB data: {course_copy_df.shape}")
 
-    course_available_pub_date_null_df = course_copy_df.loc[(course_copy_df['workflow_state'] == 'available') &
-                                                           (course_copy_df['published_at'].isnull())].copy(deep=True)
-    course_ids_available_with_no_pub_date = course_available_pub_date_null_df['canvas_id'].to_list()
-    logger.info(f"Published dates going to be fetched are: {len(course_ids_available_with_no_pub_date)}")
+    fetch_publish_date = FetchPublishedDate(CANVAS_URL, CANVAS_TOKEN, NUM_ASYNC_WORKERS,
+                                            course_copy_df, course_from_db_df, MAX_REQ_ATTEMPTS)
+    pub_dates_df = fetch_publish_date.get_published_date()
+    course_size_before_merge = course_df.shape[0]
+    course_df = pd.merge(course_df, pub_dates_df, on='canvas_id', how='left')
+    course_size_after_merge = course_df.shape[0]
+    logger.info(
+        f"Course info loss due to published date fetch/merge: {course_size_before_merge - course_size_after_merge}")
 
-    if len(course_ids_available_with_no_pub_date) > 0:
-        logger.info("*** Fetching the published date ***")
-        published_dates = FetchPublishedDate(CANVAS_URL, CANVAS_TOKEN, NUM_ASYNC_WORKERS,
-                                             course_ids_available_with_no_pub_date, MAX_REQ_ATTEMPTS)
-        start_time = time.time()
-        published_course_date = published_dates.get_published_course_date(course_ids_available_with_no_pub_date)
-        delta = time.time() - start_time
-        str_time = time.strftime("%H:%M:%S", time.gmtime(delta))
-        logger.info(f"Published date Process took {str_time}")
-
-        newly_published_date_size = len(published_course_date)
-        logger.info(f"Size Published dates fetched from API: {newly_published_date_size}")
-        logger.info(f"Database should have {published_date_in_db[0] + newly_published_date_size} published dates")
-        if len(published_course_date) > 0:
-            course_published_date_df = pd.DataFrame(published_course_date.items(), columns=['canvas_id', 'published_at'])
-            course_published_date_df['published_at'] = pd.to_datetime(course_published_date_df['published_at'],
-                                                        format=CANVAS_DATETIME_FORMAT,
-                                                        errors='coerce')
-            course_copy_df = pd.merge(course_copy_df, course_published_date_df, on='canvas_id', how='left')
-            if course_from_db_df.empty:
-                course_copy_df['published_at'] = course_copy_df['published_at_y']
-            else:
-                course_copy_df['published_at'] = course_copy_df['published_at_x'].fillna(course_copy_df['published_at_y'])
-            course_copy_df = course_copy_df.drop(['published_at_x', 'published_at_y'], axis=1)
-            course_copy_df = course_copy_df[['canvas_id','published_at']]
-            course_df = pd.merge(course_df, course_copy_df, on='canvas_id', how='left')
-        else:
-            logger.info(f"No more published date fetched than what is stored in DB")
-            course_df = pd.merge(course_df, course_from_db_df, on='canvas_id', how='left')
-    else:
-        logger.info(f"All courses seems to have Published dates, so fetching Published dates routine not needed")
-        logger.info(f"Database should have {published_date_in_db[0]} published dates ")
     course_df['created_at'] = pd.to_datetime(course_df['created_at'],
                                              format=CANVAS_DATETIME_FORMAT,
                                              errors='coerce')

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -235,6 +235,7 @@ def get_pub_course_info_from_db(db_creator_obj: DBCreator) -> pd.DataFrame:
                                     db_creator_obj.engine)
     return course_from_db_df
 
+
 # Entry point for run_jobs.py
 
 

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -289,7 +289,7 @@ def run_course_inventory() -> Sequence[DataSourceStatus]:
 
         newly_published_date_size = len(published_course_date)
         logger.info(f"Size Published dates fetched from API: {newly_published_date_size}")
-        logger.info(f"Database should have {published_date_in_db[0] + newly_published_date_size} published dates ")
+        logger.info(f"Database should have {published_date_in_db[0] + newly_published_date_size} published dates")
         if len(published_course_date) > 0:
             course_published_date_df = pd.DataFrame(published_course_date.items(), columns=['canvas_id', 'published_at'])
             course_published_date_df['published_at'] = pd.to_datetime(course_published_date_df['published_at'],

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -270,7 +270,7 @@ def run_course_inventory() -> Sequence[DataSourceStatus]:
     published_date_in_db = course_from_db_df[(course_from_db_df['published_at'].notnull())].shape
     logger.info(f"Size of published courses from DB with published date: {published_date_in_db}")
     course_copy_df = pd.merge(course_copy_df, course_from_db_df, on='canvas_id', how='left')
-    logger.info(f"Size of course data after merging from DB data {course_copy_df.shape}")
+    logger.info(f"Size of course data after merging from DB data: {course_copy_df.shape}")
 
     course_available_pub_date_null_df = course_copy_df.loc[(course_copy_df['workflow_state'] == 'available') &
                                                            (course_copy_df['published_at'].isnull())].copy(deep=True)

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -238,7 +238,8 @@ def get_course_info_from_db(db_creator_obj: DBCreator) -> pd.DataFrame:
 
 # Entry point for run_jobs.py
 
-def run_course_inventory() -> Sequence[DataSourceStatus]:
+
+def run_course_inventory() -> Sequence[Dict[str, Union[ValidDataSourceName, pd.Timestamp]]]:
     logger.info("* run_course_inventory")
     # Initialize DBCreator object
     db_creator_obj = DBCreator(INVENTORY_DB)
@@ -330,7 +331,6 @@ def run_course_inventory() -> Sequence[DataSourceStatus]:
     enroll_delta = time.time() - enroll_start
     logger.info(f'Duration of process (seconds): {enroll_delta}')
 
-
     # Record data source info for Canvas API
     canvas_data_source = DataSourceStatus(ValidDataSourceName.CANVAS_API)
 
@@ -354,7 +354,6 @@ def run_course_inventory() -> Sequence[DataSourceStatus]:
 
     udw_data_source = DataSourceStatus(
         ValidDataSourceName.UNIZIN_DATA_WAREHOUSE, udw_update_datetime)
-
 
     # Produce output
     num_term_records = len(term_df)
@@ -389,7 +388,6 @@ def run_course_inventory() -> Sequence[DataSourceStatus]:
         logger.info(f"Writing {num_canvas_usage_records} canvas course usage records to CSV")
         canvas_course_usage_df.to_csv(os.path.join('data', 'canvas_course_usage.csv'), index=False)
         logger.info('Wrote data to data/canvas_course_usage.csv')
-
 
     # Empty records from Canvas data tables in database
     logger.info('Emptying Canvas data tables in DB')

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -268,7 +268,7 @@ def run_course_inventory() -> Sequence[DataSourceStatus]:
     course_from_db_df = get_course_info_from_DB(db_creator_obj)
     logger.info(f"Size of published courses from DB with: {course_from_db_df.shape}")
     published_date_in_db = course_from_db_df[(course_from_db_df['published_at'].notnull())].shape
-    logger.info(f"Size of Published courses from DB with published date: {published_date_in_db}")
+    logger.info(f"Size of published courses from DB with published date: {published_date_in_db}")
     course_copy_df = pd.merge(course_copy_df, course_from_db_df, on='canvas_id', how='left')
     logger.info(f"Size of course data after merging from DB data {course_copy_df.shape}")
 

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -229,7 +229,7 @@ def pull_sis_section_data_from_udw(section_ids: Sequence[int], conn: connection)
 
 
 def get_course_info_from_db(db_creator_obj: DBCreator) -> pd.DataFrame:
-    logger.info("getting the course info from Database")
+    logger.info(f"Getting the course info from {db_creator_obj.db_name} database")
     course_from_db_df = pd.read_sql(f'''select canvas_id, published_at from course 
                             where workflow_state = 'available' ;''',
                                     db_creator_obj.engine)

--- a/course_inventory/published_date.py
+++ b/course_inventory/published_date.py
@@ -54,7 +54,7 @@ class FetchPublishedDate:
                 self.published_date_retry_bucket.pop(course_id)
             else:
                 # This is the case when canvas sends no Date for a course
-                logger.info(f"Course {course_id} don't have more pages")
+                logger.info(f"Course {course_id} don't have publihsed date")
 
     def published_date_resp_parsing(self, response):
         logger.info("published_date_resp_parsing Call")
@@ -149,7 +149,7 @@ class FetchPublishedDate:
                 self.published_date_resp_parsing(response)
 
         if len(self.published_date_retry_bucket) != 0:
-            logger.info(f"""Retrying now with list {len(self.published_date_retry_bucket)} 
+            logger.info(f"""Retrying now with list size {len(self.published_date_retry_bucket)} 
                         {self.published_date_retry_bucket}""")
             self.get_published_course_date(course_ids, self.published_date_retry_bucket)
 

--- a/course_inventory/published_date.py
+++ b/course_inventory/published_date.py
@@ -17,8 +17,8 @@ class FetchPublishedDate:
             canvas_url: str,
             canvas_token: str,
             num_workers: int,
-            course_data_from_api,
-            course_data_from_db,
+            course_data_from_api: pd.DataFrame,
+            course_data_from_db: pd.DataFrame,
             retry_attempts: int
     ):
         self.canvas_url = canvas_url
@@ -31,7 +31,7 @@ class FetchPublishedDate:
         # { course_id: {'url': 'https://instructure.com','count': 0} }
         self.published_date_retry_bucket: Dict[int, Dict[str, Any]] = {}
 
-    def get_next_page_url(self, response):
+    def get_next_page_url(self, response) -> None:
         """
         get the next page url from the Http response headers
         :param response:
@@ -64,7 +64,7 @@ class FetchPublishedDate:
                 # This is the case when canvas sends no Date for a course
                 logger.info(f"Course {course_id} don't have published date")
 
-    def published_date_resp_parsing(self, response):
+    def published_date_resp_parsing(self, response) -> None:
         if response is None:
             logger.info(f"Published course date response is None ")
             return
@@ -116,7 +116,7 @@ class FetchPublishedDate:
 
         return
 
-    def retry_logic_with_error(self, course_id, url):
+    def retry_logic_with_error(self, course_id, url) -> None:
         if course_id in self.published_date_retry_bucket:
             retry_count = self.published_date_retry_bucket[course_id]['count']
             if retry_count > self.retry_attempts - 1:
@@ -135,7 +135,7 @@ class FetchPublishedDate:
             }
         logger.info(f"Retry list size {len(self.published_date_retry_bucket)} for published_at date")
 
-    def filter_courses_to_fetch_published_date(self):
+    def filter_courses_to_fetch_published_date(self) -> pd.DataFrame:
         pd.set_option('display.max_column', None)
         logger.info(f"Size of courses data from API routine: {self.course_data_from_api.shape}")
         state_available_courses_from_api = self.course_data_from_api[
@@ -149,7 +149,7 @@ class FetchPublishedDate:
         logger.info(f"Size of course data after merging with DB data: {course_with_pub_date_added_from_df.shape}")
         return course_with_pub_date_added_from_df
 
-    def get_published_course_date(self, course_ids, retry_list=None):
+    def get_published_course_date(self, course_ids, retry_list=None) -> None:
         logger.info("Starting of get_published_course_date from API call")
 
         with FuturesSession(max_workers=self.num_workers) as future_session:
@@ -174,7 +174,7 @@ class FetchPublishedDate:
                         {self.published_date_retry_bucket}""")
             self.get_published_course_date(course_ids, self.published_date_retry_bucket)
 
-    def get_published_date(self):
+    def get_published_date(self) -> pd.DataFrame:
         pd.set_option('display.max_column', None)
         logger.info("Getting into fetching published date routine")
         courses_with_pub_date_col_df = self.filter_courses_to_fetch_published_date()

--- a/course_inventory/published_date.py
+++ b/course_inventory/published_date.py
@@ -211,7 +211,7 @@ class FetchPublishedDate:
 
             courses_with_pub_date_col_df = courses_with_pub_date_col_df.drop(['published_at_x', 'published_at_y'],
                                                                              axis=1)
-        logger.info(f"Size of **Newly Published dates fetched from API: {len(self.published_course_date)}")
+        logger.info(f"Size of newly published dates fetched from API: {len(self.published_course_date)}")
         logger.info(
             f"Database should have {published_date_in_db[0] + len(self.published_course_date)} published dates")
         courses_with_pub_date_col_df = courses_with_pub_date_col_df[['canvas_id', 'published_at']]

--- a/course_inventory/published_date.py
+++ b/course_inventory/published_date.py
@@ -213,6 +213,6 @@ class FetchPublishedDate:
                                                                              axis=1)
         logger.info(f"Size of newly published dates fetched from API: {len(self.published_course_date)}")
         logger.info(
-            f"Database should have {published_date_in_db[0] + len(self.published_course_date)} published dates")
+            f"There are now {published_date_in_db[0] + len(self.published_course_date)} published dates")
         courses_with_pub_date_col_df = courses_with_pub_date_col_df[['canvas_id', 'published_at']]
         return courses_with_pub_date_col_df

--- a/course_inventory/published_date.py
+++ b/course_inventory/published_date.py
@@ -140,7 +140,7 @@ class FetchPublishedDate:
         logger.info(f"Size of courses data from API routine: {self.course_data_from_api.shape}")
         state_available_courses_from_api = self.course_data_from_api[
             (self.course_data_from_api['workflow_state'] == 'available')].shape
-        logger.info(f"""Size of Published courses from API: {state_available_courses_from_api}""")
+        logger.info(f"Size of published courses from API: {state_available_courses_from_api}")
         logger.info(f"Size of published courses from DB with: {self.course_data_from_db.shape}")
         published_date_in_db = self.course_data_from_db[(self.course_data_from_db['published_at'].notnull())].shape
         logger.info(f"Size of published courses from DB with published date: {published_date_in_db}")

--- a/course_inventory/published_date.py
+++ b/course_inventory/published_date.py
@@ -125,7 +125,7 @@ class FetchPublishedDate:
                 self.published_date_retry_bucket.pop(course_id)
             else:
                 # We will give one more chance to retry
-                logger.info(f"Retry more for {course_id}  ")
+                logger.info(f"Another retry attempt will be made for {course_id}")
                 self.published_date_retry_bucket[course_id]['count'] += 1
         else:
             logger.info(f"Adding course {course_id} to retry bucket")

--- a/course_inventory/published_date.py
+++ b/course_inventory/published_date.py
@@ -128,7 +128,7 @@ class FetchPublishedDate:
                 logger.info(f"Retry more for {course_id}  ")
                 self.published_date_retry_bucket[course_id]['count'] += 1
         else:
-            logger.info(f"Putting course {course_id} to retry list")
+            logger.info(f"Adding course {course_id} to retry bucket")
             self.published_date_retry_bucket[course_id] = {
                 'url': url,
                 'count': 1,

--- a/course_inventory/published_date.py
+++ b/course_inventory/published_date.py
@@ -79,9 +79,8 @@ class FetchPublishedDate:
         status = response.result().status_code
         published_date_found = False
         if status != 200:
-            logger.info(
-                f"""Response unsuccessful for {course_id} status: {status} and time taken:{response.result().elapsed}  
-                        due to {response.result().text}""")
+            logger.warning(f"Request was unsuccessful for {course_id}")
+            logger.warning(f"Response status: {status}; time taken: {response.result().elapsed}; response text: {response.result().text}")
             self.retry_logic_with_error(course_id, url)
             return
 


### PR DESCRIPTION
Fixes #156 , #21 
This PR addresses the 
1. retry logic when the canvas is sending 500/504 and 
   1. Retrying for each course (failed with HTTP error or JSON error) 3 times in case of error 
encounted. I have never seen any API error due to JSON parsing.
   2. Average Success response time is 0-30 sec. The gateway timeout error takes about 1minutes. That's the max amount of the time that is taking
2. Only fetch those published dates with new courses added as part of API call and that from the database don't have a date
   Test case went through:
       -  With an empty database
       -  Some dates already in DB ( with both null and not null published date) and few more to 
           fetch as part of new courses
 

I tried to apply a timeout to request and response. But Not effective. Especially with a response timeout will result in total failure in fetching responses. Futures-requests responses are Yield and try/catch can stop the further pulling more responses if a particular response time out

This API is not very reliable, even after applying the steps like retry/paginating/fetching dates that aren't there in DB canvas sometimes don't send data.  if I go to the browser and do the API call I can see the date. 
