### PR TITLE
Relax data types of SIS IDs (#165)

### DIFF
--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -112,7 +112,7 @@ def slim_down_course_data(course_data: List[Dict]) -> List[Dict]:
     for course_dict in course_data:
         slim_course_dict = {
             'canvas_id': course_dict['id'],
-            'sis_id': str(course_dict['sis_course_id']),
+            'sis_id': course_dict['sis_course_id'],
             'name': course_dict['name'],
             'account_id': course_dict['account_id'],
             'term_id': course_dict['enrollment_term_id'],
@@ -210,15 +210,6 @@ def gather_account_data_from_api(account_ids: Sequence[int]) -> pd.DataFrame:
 
 # Function(s) - UDW
 
-def process_sis_id(orig_sis_id: str) -> Union[int, None]:
-    try:
-        sis_id = int(orig_sis_id)
-        return sis_id
-    except ValueError:
-        logger.debug(f'Invalid sis_id found: {orig_sis_id}')
-        return None
-
-
 def pull_sis_section_data_from_udw(section_ids: Sequence[int], conn: connection) -> pd.DataFrame:
     section_ids_tup = tuple(section_ids)
     section_query = f'''
@@ -229,7 +220,6 @@ def pull_sis_section_data_from_udw(section_ids: Sequence[int], conn: connection)
     '''
     logger.info('Making course_section_dim query against UDW')
     udw_section_df = pd.read_sql(section_query, conn, params=(section_ids_tup,))
-    udw_section_df['sis_id'] = udw_section_df['sis_id'].map(process_sis_id, na_action='ignore')
     logger.debug(udw_section_df.head())
     return udw_section_df
 

--- a/db/migrations/0019.relax_sis_ids.py
+++ b/db/migrations/0019.relax_sis_ids.py
@@ -1,0 +1,18 @@
+#
+# file: migrations/0019.relax_sis_ids.py
+#
+from yoyo import step
+
+
+steps = [
+    step('''
+        ALTER TABLE course_section
+        MODIFY
+            sis_id VARCHAR(256) NULL;
+    '''),
+    step('''
+        ALTER TABLE account
+        MODIFY
+            sis_id VARCHAR(256) NULL;
+    ''')
+]


### PR DESCRIPTION
To resolve insertion errors and create consistency, this PR changes via a migration two SIS ID fields (`course_section.sis_id` and `account.sis_id`) to the `VARCHAR(256)` data type in the database, mirroring the Canvas data model. (Note that the `course.sis_id` was previously changed to this type in PR #160.) The PR also removes a mapping function previously used to normalize `course_section.sis_id`, as well as an unnecessary string conversion call in the `slim_down_course_data` function (the data was already a string). The PR aims to resolve issue #165.