### PR TITLE
Handle possibility of duplicate courses being inserted to `course` table (#174)

### DIFF
--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -177,6 +177,10 @@ def gather_course_data_from_api(account_id: int, term_ids: Sequence[int]) -> pd.
 
     course_df = pd.DataFrame(course_dicts_with_students)
     course_df = course_df.drop(['total_students'], axis='columns')
+    orig_course_count = len(course_df)
+    course_df = course_df.drop_duplicates(subset=['canvas_id'], keep='last')
+    logger.info(f'{orig_course_count - len(course_df)} course records were dropped')
+
     logger.debug(course_df.head())
     return course_df
 

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -173,13 +173,13 @@ def gather_course_data_from_api(account_id: int, term_ids: Sequence[int]) -> pd.
     num_course_dicts_with_students = len(course_dicts_with_students)
 
     logger.info(f'Course records with students: {num_course_dicts_with_students}')
-    logger.info(f'Dropped {num_course_dicts - num_course_dicts_with_students} records')
+    logger.info(f'Dropped {num_course_dicts - num_course_dicts_with_students} course record(s) with no students')
 
     course_df = pd.DataFrame(course_dicts_with_students)
     course_df = course_df.drop(['total_students'], axis='columns')
     orig_course_count = len(course_df)
     course_df = course_df.drop_duplicates(subset=['canvas_id'], keep='last')
-    logger.info(f'{orig_course_count - len(course_df)} course records were dropped')
+    logger.info(f'Dropped {orig_course_count - len(course_df)} duplicate course record(s)')
 
     logger.debug(course_df.head())
     return course_df


### PR DESCRIPTION
Similar to PR #146, this PR adds duplicate dropping to the creation of `course` records to avoid possible errors when inserting into the database. The modifications include the use of `pd.DataFrame.drop_duplicates` with the `subset` parameter to limit duplicate consideration to the PK (`canvas_id`) and the `keep` parameter to ensure the second record found is kept. This change is responding to incidents in the production and test processes where a different course in each process seems to have been duplicated. The PR aims to resolve issue #174.