### PR TITLE
Exit if max attempt limit is reached in make_request_using_api_utils (#161)

### DIFF
--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -1,5 +1,5 @@
 # standard libraries
-import json, logging, os, time
+import json, logging, os, sys, time
 from json.decoder import JSONDecodeError
 from typing import Any, Dict, List, Sequence, Union
 
@@ -70,7 +70,8 @@ def make_request_using_api_utils(url: str, params: Union[Dict[str, Any], None] =
                 logger.info('Beginning next attempt')
 
     logger.error('The maximum number of request attempts was reached')
-    return response
+    logger.error('Data could not be gathered; the program will exit')
+    sys.exit(1)
 
 
 def gather_term_data_from_api(account_id: int, term_ids: Sequence[int]) -> pd.DataFrame:

--- a/course_inventory/inventory.py
+++ b/course_inventory/inventory.py
@@ -70,7 +70,8 @@ def make_request_using_api_utils(url: str, params: Union[Dict[str, Any], None] =
                 logger.info('Beginning next attempt')
 
     logger.error('The maximum number of request attempts was reached')
-    logger.error('Data could not be gathered; the program will exit')
+    logger.error(f'Data could not be gathered from the URL with the ending "{url}"')
+    logger.error('The program will exit')
     sys.exit(1)
 
 


### PR DESCRIPTION
This PR modifies the `make_request_using_api_utils` function from `inventory.py` -- used by the `course`, `account`, and `term` Canvas data fetching -- so that it exits the program if the maximum number of attempts are reached. This ensures that the `Response` object returned by the function is always a valid one. The PR aims to resolve issue #161.

I thought for a little while about whether the program should continue after failing multiple times, and I decided that for these requests, the dataset would be incomplete without the data. We would either be missing 100 courses or a foreign key constraint would fail from `course` -> `account` or `term`. Note that I have not yet seen this situation in our deployed processes; if we are concerned that this might happen, we can bump the max request attempts to `4`.