### PR TITLE
Update .dockerignore (#180)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # config
 **/env.*
 venv
+.vscode
 
 # data
 **/*.csv

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,12 @@
 # config
-env.*
+**/env.*
 venv
 
 # data
-*.csv
+**/*.csv
 .data
 
 # etc
 .DS_Store
-.vscode
-*.pyc
-__pycache__
+**/*.pyc
+**/__pycache__

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 # config
-env.json
+env.*
 venv
 
 # data
@@ -8,6 +8,6 @@ venv
 
 # etc
 .DS_Store
-*.pyc
 .vscode
+*.pyc
 __pycache__


### PR DESCRIPTION
This PR updates the repo's `.dockerignore` file to ensure unnecessary and sensitive files are not included in Docker images built locally. Changes include use of the `**/` Docker-specific syntax to properly find files with certain patterns in any directory; widening of the `env` pattern to capture HJSON configuration files; and the removal of the `.vscode` directory from the list (as it might be needed in our deployment environments). The PR aims to resolve issue #180.