### PR TITLE
Fix MiVideo course ID conversion bug (#188)

### DIFF
--- a/mivideo/mivideo_extract.py
+++ b/mivideo/mivideo_extract.py
@@ -284,6 +284,22 @@ class MiVideoExtract:
 
     @staticmethod
     def _makeCourseData(resultDictionaries: Sequence[Dict], categoryFilter: str) -> pd.DataFrame:
+        """
+        Turn Kaltura API media query results into DataFrame of media ID and Canvas course ID.
+
+        MiVideo media in Kaltura that are published to Canvas have categories added to them with
+        a very specific, case-sensitive format::
+
+            Canvas_UMich>site>channels>𝒏𝒏𝒏𝒏𝒏𝒏>InContext
+
+        Where `𝒏𝒏𝒏𝒏𝒏𝒏` is the ID of a course site in Canvas, which are integers, often of 6-digits.
+
+        We want only those IDs that are integers, not hexadecimal or other strings.
+
+        :param resultDictionaries: a sequence of KalturaMediaEntry objects converted to dictionaries
+        :param categoryFilter: the base Kaltura category, usually `Canvas_UMich`
+        :return:
+        """
         courseData: pd.DataFrame = pd.DataFrame.from_records(
             resultDictionaries, columns=('id', 'categories',)
         ).rename(columns={'id': 'media_id', 'categories': 'course_id', })

--- a/mivideo/mivideo_extract.py
+++ b/mivideo/mivideo_extract.py
@@ -295,7 +295,7 @@ class MiVideoExtract:
             c.endswith('>InContext') for c in courseData['course_id']]
 
         courseData['course_id'] = courseData['course_id'].str.replace(
-            r'^' + categoryFilter + r'.*>([0-9]+).*$',
+            r'^' + categoryFilter + r'.*>([0-9]+)(>InContext)?$',
             lambda m: m.groups()[0], regex=True
         )
 


### PR DESCRIPTION
Fixes #188.

Because the regex wasn't explicit enough, Kaltura categories with hexadecimal values (e.g., "Canvas_UMich>site>channels>5430bafe907cca901a0f11646470dd64244ebd5f") would have all digits following the first non-integer digit stripped and the remaining ones (i.e., "5430") were incorrectly treated as the Canvas course ID.  The regex now specifically looks for integer digits, optionally followed by ">InContext", and the end of the string. 

## Review
I **_humbly_** request that comments on this PR be nested under a single review per reviewer.  It helps me when the comments are organized this way, especially if the comments request changes in the code.

If I've requested a review from you but you are definitely unable to review this PR, please leave a comment saying so (please state _why_ you're unable to review, that would be appreciated), tell the other reviewers that the review will be left to them, and remove your name from the list of reviewers.

## Testing

Ensure that no course IDs less than 99 are saved to the DB and neither should course IDs 551, 3704, or 5430.  All of those were erroneously converted from hexadecimal course IDs.

## Deployment

During deployment, to eliminate the erroneous courses from the DB, it's best to completely rebuild the `mivideo_media_courses` and `mivideo_media_created` tables.  Drop the contents of those tables and the normal process will automatically fill them in again with data from 01 March 2020 onwards.