### PR TITLE
Improve MiVideo course ID parsing (#150)

### DIFF
--- a/mivideo/mivideo_extract.py
+++ b/mivideo/mivideo_extract.py
@@ -334,7 +334,7 @@ class MiVideoExtract:
             logger.debug(f'Course IDs to be removed:\n{courseData[invalidCourseIdIndex]}')
             courseData = courseData[validCourseIdIndex]  # keep the valid ones
 
-        courseData.drop_duplicates(inplace=True)
+        courseData = courseData.drop_duplicates()
 
         return courseData
 

--- a/mivideo/mivideo_extract.py
+++ b/mivideo/mivideo_extract.py
@@ -331,8 +331,7 @@ class MiVideoExtract:
         if (not validCourseIdIndex.all()):  # not all all index items are True
             logger.debug('Non-decimal course IDs to be removed:\n'
                          f'{courseData[~validCourseIdIndex]}')
-
-        courseData = courseData[validCourseIdIndex].drop_duplicates()
+            courseData = courseData[validCourseIdIndex].drop_duplicates()
 
         return courseData
 

--- a/mivideo/mivideo_extract.py
+++ b/mivideo/mivideo_extract.py
@@ -329,9 +329,12 @@ class MiVideoExtract:
         validCourseIdIndex = courseData['course_id'].map(str.isdecimal)
 
         if (not validCourseIdIndex.all()):  # not all all index items are True
-            logger.debug('Non-decimal course IDs to be removed:\n'
-                         f'{courseData[~validCourseIdIndex]}')
-            courseData = courseData[validCourseIdIndex].drop_duplicates()
+            invalidCourseIdIndex = ~validCourseIdIndex
+            logger.info(f'Removing ({invalidCourseIdIndex.values.sum()}) non-decimal course IDs...')
+            logger.debug(f'Course IDs to be removed:\n{courseData[invalidCourseIdIndex]}')
+            courseData = courseData[validCourseIdIndex]  # keep the valid ones
+
+        courseData.drop_duplicates(inplace=True)
 
         return courseData
 


### PR DESCRIPTION
Resolves #150.

## Summary
Simplifies the transformation of Kaltura media categories to Canvas course ID numbers and removes dependency on regular expressions.  Both make it easier for maintainers to understand.

## Details
* Don't rename the `categories` column to `course_id` immediately.  Create the new column by transforming the data, then delete the old column.  Maybe not as efficient, but easier to understand.
* Avoid using Pandas' `str` property of `Series` objects.  Use `map()` instead, which is something maintainers will probably be familiar with from base Python, JavaScript, and other languages.  🎩 @ssciolla 
* Replace regular expression use with splitting category strings on `>`, the delimiter Kaltura uses in its category hierarchies.
* Probably improved efficiency in the removal of non-decimal course IDs part of the process.  No longer uses a regular expression to find and log the bad items, followed by using `str.isdecimal()` to remove them, which processes all `course_id` values **_twice_**.  Instead, process them once with `map(str.isdecimal)` to get a Boolean index of all rows and use negation (`~`) to log them.

## Review
I **_humbly_** request that comments on this PR be nested under a single review per reviewer.  It helps me when the comments are organized this way, especially if the comments request changes in the code.

If I've requested a review from you but you are definitely unable to review this PR, please leave a comment saying so (please state _why_ you're unable to review, that would be appreciated), tell the other reviewers that the review will be left to them, and remove your name from the list of reviewers.

