### PR TITLE
Add relax_course_name migration (#198)

### DIFF
--- a/db/migrations/0023.relax_course_name.py
+++ b/db/migrations/0023.relax_course_name.py
@@ -1,0 +1,16 @@
+#
+# file: migrations/0023.relax_course_name.py
+#
+from yoyo import step
+
+steps = [
+    step('''
+        ALTER TABLE course
+        MODIFY
+            name VARCHAR(256) NOT NULL;
+    '''),
+    step('''
+        ALTER TABLE course
+        DROP INDEX name;
+    ''')
+]

--- a/db/migrations/0023.relax_course_name.py
+++ b/db/migrations/0023.relax_course_name.py
@@ -6,11 +6,11 @@ from yoyo import step
 steps = [
     step('''
         ALTER TABLE course
-        MODIFY
-            name VARCHAR(256) NOT NULL;
+        DROP INDEX name;
     '''),
     step('''
         ALTER TABLE course
-        DROP INDEX name;
+        MODIFY
+            name VARCHAR(256) NOT NULL;
     ''')
 ]


### PR DESCRIPTION
This PR relaxes the `course.name` field of the `course` table by removing its unique constraint (index) and extending the length to a more flexible `256`. The PR aims to resolve issue #198.

Test: The PR addresses a production integrity error preventing insertion of two courses with the same name in the summer term. Running the `COURSE_INVENTORY` job for that term should confirm that this is working properly. 